### PR TITLE
+ Documentation, + Error handling, - Index error

### DIFF
--- a/src/daos/document_dao.py
+++ b/src/daos/document_dao.py
@@ -22,13 +22,17 @@ class DocumentDao:
             empty paragraphs, figure captions, and the appendices '''
         counter = 0
 
-        while counter < len(self.document.doc.paragraphs) and self.document.doc.paragraphs[counter].text != 'Appendices':
+        while counter < len(self.document.doc.paragraphs): 
             paragraph = self.document.doc.paragraphs[counter]
             counter += 1
 
-        if not paragraph.style.name.startswith('Heading') and \
-            paragraph.text != '' and not paragraph.text.startswith('Figure'):
-            yield paragraph 
+            if paragraph.text.startswith('Appendix') or paragraph.text.startswith('Appendices'):
+                break
+
+            if not paragraph.style.name.startswith('Heading') and not paragraph.style.name.startswith('Title') and not paragraph.style.name.startswith('Subtitle') and \
+                paragraph.text != '' and not paragraph.text.startswith('Figure'):
+                yield paragraph
+
 
         for table in self.document.tables:
             for row in table.rows:
@@ -37,13 +41,17 @@ class DocumentDao:
                         if paragraph.text != '':
                             yield paragraph
 
+    paragraph_count = 0
+
     def set_words(self):
         ''' Yields words from the paragraphs, excluding full stops and dashes '''
         for paragraph in self.document.paras:
+            self.paragraph_count += 1
+            print('Paragraph ' + str(self.paragraph_count) + ' style:' + str(paragraph.style.name))
             paragraph = paragraph.text
             words = paragraph.split()
             for word in words:
-                print(word)
+                print(word) 
                 if word != ('.' or '–'):
                     yield word
 

--- a/src/daos/document_dao.py
+++ b/src/daos/document_dao.py
@@ -3,26 +3,32 @@ from models.document import Document
 
 
 class DocumentDao:
+    ''' Data access object for interacting with word documents '''
+
     def __init__(self, file_path):
+        ''' Initialises the document instance with the file path '''
         self.document = Document(file_path)
 
         self.initialise_document()
 
     def initialise_document(self):
+        ''' Initialises the document instance with the tables, paragraphs and words '''
         self.document.tables = self.document.doc.tables
         self.document.paras = list(self.set_paragraphs())
         self.document.words = list(self.set_words())
 
     def set_paragraphs(self):
+        ''' Yields all the paragraphs in the document, skipping headings, 
+            empty paragraphs, figure captions, and the appendices '''
         counter = 0
 
-        while self.document.doc.paragraphs[counter].text != 'Appendices':
+        while counter < len(self.document.doc.paragraphs) and self.document.doc.paragraphs[counter].text != 'Appendices':
             paragraph = self.document.doc.paragraphs[counter]
             counter += 1
 
-            if not paragraph.style.name.startswith('Heading') and \
-                paragraph.text != '' and not paragraph.text.startswith('Figure'):
-                yield paragraph
+        if not paragraph.style.name.startswith('Heading') and \
+            paragraph.text != '' and not paragraph.text.startswith('Figure'):
+            yield paragraph 
 
         for table in self.document.tables:
             for row in table.rows:
@@ -32,12 +38,15 @@ class DocumentDao:
                             yield paragraph
 
     def set_words(self):
+        ''' Yields words from the paragraphs, excluding full stops and dashes '''
         for paragraph in self.document.paras:
             paragraph = paragraph.text
             words = paragraph.split()
             for word in words:
+                print(word)
                 if word != ('.' or '–'):
                     yield word
 
     def print_word_count(self):
+        ''' Prints total word count of document '''
         print(len(self.document.words))

--- a/src/daos/document_dao.py
+++ b/src/daos/document_dao.py
@@ -6,20 +6,16 @@ class DocumentDao:
     ''' Data access object for interacting with word documents '''
 
     def __init__(self, file_path):
-        ''' Initialises the document instance with the file path '''
         self.document = Document(file_path)
 
         self.initialise_document()
 
     def initialise_document(self):
-        ''' Initialises the document instance with the tables, paragraphs and words '''
         self.document.tables = self.document.doc.tables
         self.document.paras = list(self.set_paragraphs())
         self.document.words = list(self.set_words())
 
     def set_paragraphs(self):
-        ''' Yields all the paragraphs in the document, skipping headings, 
-            empty paragraphs, figure captions, and the appendices '''
         counter = 0
 
         while counter < len(self.document.doc.paragraphs): 
@@ -33,7 +29,6 @@ class DocumentDao:
                 paragraph.text != '' and not paragraph.text.startswith('Figure'):
                 yield paragraph
 
-
         for table in self.document.tables:
             for row in table.rows:
                 for cell in row.cells:
@@ -44,10 +39,9 @@ class DocumentDao:
     paragraph_count = 0
 
     def set_words(self):
-        ''' Yields words from the paragraphs, excluding full stops and dashes '''
         for paragraph in self.document.paras:
             self.paragraph_count += 1
-            print('Paragraph ' + str(self.paragraph_count) + ' style:' + str(paragraph.style.name))
+            print(f'Paragraph {self.paragraph_count} style: {paragraph.style.name}')
             paragraph = paragraph.text
             words = paragraph.split()
             for word in words:
@@ -56,5 +50,4 @@ class DocumentDao:
                     yield word
 
     def print_word_count(self):
-        ''' Prints total word count of document '''
-        print(len(self.document.words))
+        print(f'words: {len(self.document.words)}')

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,6 @@ from daos.document_dao import DocumentDao
 
 
 if __name__ == '__main__':
-    print('Running main.py') #debugging
     file_path = input('File path to document: ')
     print('')
     document_dao = DocumentDao(file_path)

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@ from daos.document_dao import DocumentDao
 
 
 if __name__ == '__main__':
+    print('Running main.py') #debugging
     file_path = input('File path to document: ')
     print('')
     document_dao = DocumentDao(file_path)

--- a/src/models/document.py
+++ b/src/models/document.py
@@ -1,11 +1,15 @@
 import docx
 
 class Document:
+    ''' Represents a document with tables, paragraphs, and words '''
+
     def __init__(self, file_path):
+        ''' Initialises the document instance with the file path '''
         try:
             self.doc = docx.Document(file_path)
-        except Exception:
-            print("Document couldn't be found...")
+        except Exception as e:
+            raise FileNotFoundError(f"Document couldn't be found at {file_path}") from e
+            #print(f"Document couldn't be found at {file_path}")
 
         self.tables = []
         self.paras = []

--- a/src/models/document.py
+++ b/src/models/document.py
@@ -4,12 +4,10 @@ class Document:
     ''' Represents a document with tables, paragraphs, and words '''
 
     def __init__(self, file_path):
-        ''' Initialises the document instance with the file path '''
         try:
             self.doc = docx.Document(file_path)
         except Exception as e:
             raise FileNotFoundError(f"Document couldn't be found at {file_path}") from e
-            #print(f"Document couldn't be found at {file_path}")
 
         self.tables = []
         self.paras = []


### PR DESCRIPTION
- Added documentation.
- Fixed error handling when file path is not valid/file not found so it prints an error instead of raising an error in the terminal.
- Fixed paragraph indexing error where counter exceeded the number of paragraphs when searching for an appendix that wasn't there.

**Note: the only words that are counted are the last paragraph of a document. I have added debugging to print the words that are included to show this.**