### PR TITLE
fix: Error handling for incorrect/open file paths

### DIFF
--- a/src/daos/document_dao.py
+++ b/src/daos/document_dao.py
@@ -12,6 +12,7 @@ class DocumentDao:
 
         self.initialise_document()
 
+    @property
     def document_loaded(self):
         return self.document.doc is not None
 

--- a/src/daos/document_dao.py
+++ b/src/daos/document_dao.py
@@ -7,8 +7,13 @@ class DocumentDao:
 
     def __init__(self, file_path):
         self.document = Document(file_path)
+        if self.document.doc == None:
+            return
 
         self.initialise_document()
+
+    def document_loaded(self):
+        return self.document.doc is not None
 
     def initialise_document(self):
         self.document.tables = self.document.doc.tables

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,6 @@
 import sys
 from daos.document_dao import DocumentDao
 
-
 if __name__ == '__main__':
     if len(sys.argv) > 1:
         file_path = sys.argv[1]
@@ -9,6 +8,6 @@ if __name__ == '__main__':
         file_path = input('Enter file path to document without quotation marks: ')
     print('')
     document_dao = DocumentDao(file_path)
-    if document_dao.document_loaded():
+    if document_dao.document_loaded: 
         document_dao.print_word_count()
     print('')

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,12 @@
+import sys
 from daos.document_dao import DocumentDao
 
 
 if __name__ == '__main__':
-    file_path = input('File path to document: ')
+    if len(sys.argv) > 1:
+        file_path = sys.argv[1]
+    else:
+        file_path = input('Enter file path to document without quotation marks: ')
     print('')
     document_dao = DocumentDao(file_path)
     if document_dao.document_loaded():

--- a/src/main.py
+++ b/src/main.py
@@ -5,5 +5,6 @@ if __name__ == '__main__':
     file_path = input('File path to document: ')
     print('')
     document_dao = DocumentDao(file_path)
-    document_dao.print_word_count()
+    if document_dao.document_loaded():
+        document_dao.print_word_count()
     print('')

--- a/src/models/document.py
+++ b/src/models/document.py
@@ -11,11 +11,11 @@ class Document:
         try:
             self.doc = docx.Document(file_path)
         except FileNotFoundError:
-            print(f"File not found. Please ensure the file path is correct and not contained within speech or quotation marks.")
+            print("File not found. Please ensure the file path is correct and not contained within speech or quotation marks.")
         except PermissionError:
-            print(f"Permission denied. Please ensure the file is not open in another program.")
+            print("Permission denied. Please ensure the file is not open in another program.")
         except PackageNotFoundError:
-            print(f"Package not found. Please ensure the file is closed in other programs and has a valid '.docx' format.")
+            print("Package not found. Please ensure the file is closed in other programs and has a valid '.docx' format.")
         except Exception as e:
             print(f"An unexpected error occurred: {str(e)}.\nPlease ensure the following:\n\t1. The file path is correct.\n\t2. The file path is not contained within speech or quotation marks.\n\t3. The file is not open in another program.")
             return

--- a/src/models/document.py
+++ b/src/models/document.py
@@ -5,11 +5,13 @@ class Document:
     ''' Represents a document with tables, paragraphs, and words '''
 
     def __init__(self, file_path):
+        self.doc = None
+
         try:
             self.doc = docx.Document(file_path)
         except Exception as e:
-            raise FileNotFoundError(
-                f"Document couldn't be found at {file_path}") from e
+            print(f"An unexpected error occurred: {str(e)}.\nPlease ensure the following:\n\t1. The file path is correct.\n\t2. The file path is not contained within speech or quotation marks.\n\t3. The file is not open in another program.")
+            return
 
         self.tables = []
         self.paras = []

--- a/src/models/document.py
+++ b/src/models/document.py
@@ -10,15 +10,9 @@ class Document:
 
         try:
             self.doc = docx.Document(file_path)
-        except FileNotFoundError:
-            print("File not found. Please ensure the file path is correct and not contained within speech or quotation marks.")
-        except PermissionError:
-            print("Permission denied. Please ensure the file is not open in another program.")
         except PackageNotFoundError:
             print("Package not found. Please ensure the file is closed in other programs and has a valid '.docx' format.")
-        except Exception as e:
-            print(f"An unexpected error occurred: {str(e)}.\nPlease ensure the following:\n\t1. The file path is correct.\n\t2. The file path is not contained within speech or quotation marks.\n\t3. The file is not open in another program.")
-            return
+            return 
 
         self.tables = []
         self.paras = []

--- a/src/models/document.py
+++ b/src/models/document.py
@@ -1,4 +1,5 @@
 import docx
+from docx.opc.exceptions import PackageNotFoundError
 
 
 class Document:
@@ -9,6 +10,12 @@ class Document:
 
         try:
             self.doc = docx.Document(file_path)
+        except FileNotFoundError:
+            print(f"File not found. Please ensure the file path is correct and not contained within speech or quotation marks.")
+        except PermissionError:
+            print(f"Permission denied. Please ensure the file is not open in another program.")
+        except PackageNotFoundError:
+            print(f"Package not found. Please ensure the file is closed in other programs and has a valid '.docx' format.")
         except Exception as e:
             print(f"An unexpected error occurred: {str(e)}.\nPlease ensure the following:\n\t1. The file path is correct.\n\t2. The file path is not contained within speech or quotation marks.\n\t3. The file is not open in another program.")
             return


### PR DESCRIPTION
This commit addresses error handling in the following scenarios:
- When the file path is incorrect or the file is not found
- When the file path is contained within speech or quotation marks
- When the file is open in another program, causing a permission error

Now, instead of raising an error in the terminal, a message is printed to the user to detail what the likely cause of the problem is and what they can do.